### PR TITLE
Added "quality" and "led" parameters

### DIFF
--- a/camerapi.html
+++ b/camerapi.html
@@ -99,9 +99,35 @@
          <label for="node-input-sharpness"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.sharpness"></span></label>
 		 <input type="text" id="node-input-sharpness" placeholder="-100 to 100" >
     </div>
+    <div class="form-row node-input-imageeffect">
+         <label for="node-input-imageeffect"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.imageeffect"></span></label>
+         <select id="node-input-imageeffect">
+            <option value="none">none</option>
+            <option value="negative">negative</option>
+            <option value="solarize">solarize</option>
+            <option value="sketch">sketch</option>
+            <option value="denoise">denoise</option>
+            <option value="emboss">emboss</option>
+            <option value="oilpaint">oilpaint</option>
+            <option value="hatch">hatch</option>
+            <option value="gpen">gpen</option>
+            <option value="pastel">pastel</option>
+            <option value="watercolor">watercolor</option>
+            <option value="blur">blur</option>
+            <option value="saturation">saturation</option>
+            <option value="colorswap">colorswap</option>
+            <option value="washedout">washedout</option>
+            <option value="posterise">posterise</option>
+            <option value="colorpoint">colorpoint</option>
+            <option value="colorbalance">colorbalance</option>
+            <option value="cartoon">cartoon</option>
+            <option value="deinterlace1">deinterlace1</option>
+            <option value="deinterlace2">deinterlace2</option>
+        </select>
+    </div>
     <div class="form-row node-input-agcwait">
          <label for="node-input-agcwait"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.agcwait"></span></label>
-		 <input type="text" id="node-input-agcwait" placeholder="0.3" >
+		 <input type="text" id="node-input-agcwait" placeholder="0.0 to 1.0" >
     </div>
     <div class="form-row node-input-quality">
          <label for="node-input-quality"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.quality"></span></label>

--- a/camerapi.html
+++ b/camerapi.html
@@ -151,9 +151,9 @@
             contrast: {value:"0", required:true},
             sharpness: {value:"0", required:true},
             imageeffect: {value:"none", required:true},
-            agcwait: {value:"0.3", required:true},
-            quality: {value:"80", required:true},
-            led: {value:"True", required:true},
+            agcwait: {value:"0.3", required:false},
+            quality: {value:"80", required:false},
+            led: {value:"1", required:false},
             name: {value:""}
         },
         inputs:1,

--- a/camerapi.html
+++ b/camerapi.html
@@ -110,8 +110,8 @@
     <div class="form-row node-input-led">
          <label for="node-input-led"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.led"></span></label>
 	 <select id="node-input-led">
-            <option value="True">On</option>
-            <option value="False">Off</option>
+            <option value="1">On</option>
+            <option value="0">Off</option>
 	</select>
     </div>
     <div class="form-row node-input-name">

--- a/camerapi.html
+++ b/camerapi.html
@@ -130,7 +130,7 @@
     <p>As default directory you should have a <b>/home/pi/Pictures</b> filedirectory to use <b>msg.filedefpath=0</b> </p>
     <p>To ensure correct exposure, a delay is required between instantiating the camera and taking the picture - set how long you want this delay to be with the agcwait parameter (default 0.3s).</p>
     <p>If the image format is set to "JPEG", the "quality" parameter can be used to control the amount of JPEG compression applied (0-100, with 100 resulting in the least compression). If not specified, quality defaults to 80. This parameter is ignored for other image formats.</p>
-    <p>The camera LED can be controlled with the "LED" parameter. When set to "On" (True, default), the camera's LED will be activated during the capture.</p>
+    <p>The camera LED can be controlled with the "LED" parameter. When set to "On" (1, default), the camera's LED will be activated during the capture.</p>
 </script>
 
 <script type="text/javascript">

--- a/camerapi.html
+++ b/camerapi.html
@@ -99,35 +99,20 @@
          <label for="node-input-sharpness"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.sharpness"></span></label>
 		 <input type="text" id="node-input-sharpness" placeholder="-100 to 100" >
     </div>
-    <div class="form-row node-input-imageeffect">
-         <label for="node-input-imageeffect"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.imageeffect"></span></label>
-	     <select id="node-input-imageeffect">
-            <option value="none">none</option>
-            <option value="negative">negative</option>
-            <option value="solarize">solarize</option>
-            <option value="sketch">sketch</option>
-            <option value="denoise">denoise</option>
-            <option value="emboss">emboss</option>
-            <option value="oilpaint">oilpaint</option>
-            <option value="hatch">hatch</option>
-            <option value="gpen">gpen</option>
-            <option value="pastel">pastel</option>
-            <option value="watercolor">watercolor</option>
-            <option value="blur">blur</option>
-            <option value="saturation">saturation</option>
-            <option value="colorswap">colorswap</option>
-            <option value="washedout">washedout</option>
-            <option value="posterise">posterise</option>
-            <option value="colorpoint">colorpoint</option>
-            <option value="colorbalance">colorbalance</option>
-            <option value="cartoon">cartoon</option>
-            <option value="deinterlace1">deinterlace1</option>
-            <option value="deinterlace2">deinterlace2</option>
-		</select>
-    </div>
     <div class="form-row node-input-agcwait">
          <label for="node-input-agcwait"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.agcwait"></span></label>
-         <input type="text" id="node-input-agcwait" placeholder="0.0 to 1.0" >
+		 <input type="text" id="node-input-agcwait" placeholder="0.3" >
+    </div>
+    <div class="form-row node-input-quality">
+         <label for="node-input-quality"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.quality"></span></label>
+		 <input type="text" id="node-input-quality" placeholder="80" >
+    </div>
+    <div class="form-row node-input-led">
+         <label for="node-input-led"><i class="fa fa-camera"></i> <span data-i18n="camerapi.label.led"></span></label>
+	 <select id="node-input-led">
+            <option value="True">On</option>
+            <option value="False">Off</option>
+	</select>
     </div>
     <div class="form-row node-input-name">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="camerapi.label.name"></span></label>
@@ -144,6 +129,8 @@
     <p>Otherwise the <b>msg.payload</b> will contain the photo as an binary object. </p>
     <p>As default directory you should have a <b>/home/pi/Pictures</b> filedirectory to use <b>msg.filedefpath=0</b> </p>
     <p>To ensure correct exposure, a delay is required between instantiating the camera and taking the picture - set how long you want this delay to be with the agcwait parameter (default 0.3s).</p>
+    <p>If the image format is set to "JPEG", the "quality" parameter can be used to control the amount of JPEG compression applied (0-100, with 100 resulting in the least compression). If not specified, quality defaults to 80. This parameter is ignored for other image formats.</p>
+    <p>The camera LED can be controlled with the "LED" parameter. When set to "On" (True, default), the camera's LED will be activated during the capture.</p>
 </script>
 
 <script type="text/javascript">
@@ -165,6 +152,8 @@
             sharpness: {value:"0", required:true},
             imageeffect: {value:"none", required:true},
             agcwait: {value:"0.3", required:true},
+            quality: {value:"80", required:true},
+            led: {value:"True", required:true},
             name: {value:""}
         },
         inputs:1,

--- a/camerapi.js
+++ b/camerapi.js
@@ -292,7 +292,7 @@ module.exports = function(RED) {
 					if (node.led) {
 						led = node.led;
 					} else {
-						led = True;					
+						led = 1;					
 					}
 				}
 			cl += " " + led;

--- a/camerapi.js
+++ b/camerapi.js
@@ -47,6 +47,8 @@ module.exports = function(RED) {
 		this.contrast = config.contrast;
 		this.imageeffect = config.imageeffect;
 		this.agcwait = config.agcwait;
+		this.quality = config.quality;
+		this.led = config.led;
 		this.name =  config.name;
 		this.activeProcesses = {};
 
@@ -76,6 +78,8 @@ module.exports = function(RED) {
 			var contrast;
 			var imageeffect;
 			var agcwait;
+			var quality;
+			var led;
 			var rotation;
 
 			node.status({fill:"green",shape:"dot",text:"connected"});
@@ -268,6 +272,30 @@ module.exports = function(RED) {
 					}
 				}
 			cl += " " + agcwait;
+			
+			// jpeg quality
+			if ((msg.quality) && (msg.quality !== "")) {
+				quality = msg.quality;
+				} else {
+					if (node.quality) {
+						quality = node.quality;
+					} else {
+						quality = 80;					
+					}
+				}
+			cl += " " + quality;
+			
+			// led on/off
+			if ((msg.led) && (msg.led !== "")) {
+				led = msg.led;
+				} else {
+					if (node.led) {
+						led = node.led;
+					} else {
+						led = True;					
+					}
+				}
+			cl += " " + led;
 
 			if (RED.settings.verbose) { node.log(cl); }
 

--- a/lib/python/get_photo.py
+++ b/lib/python/get_photo.py
@@ -17,6 +17,8 @@ contrast = int(sys.argv[10])
 sharpness = int(sys.argv[11])
 imageeffect = sys.argv[12]
 agcwait = float(sys.argv[13])
+quality = int(sys.argv[14])
+led = bool(sys.argv[15])
 
 # consider jpeg
 if fileFormat == "jpg":
@@ -56,6 +58,11 @@ with picamera.PiCamera() as camera:
         camera.sharpness = sharpness
         camera.contrast = contrast
         camera.image_effect = imageeffect
+        camera.led = led
+        
+        if i_format == "jpeg":
+            camera.quality = quality
+            
         time.sleep(agcwait)
         camera.capture(picfile, i_format)
 

--- a/lib/python/get_photo.py
+++ b/lib/python/get_photo.py
@@ -60,11 +60,14 @@ with picamera.PiCamera() as camera:
         camera.image_effect = imageeffect
         camera.led = led
         
-        if i_format == "jpeg":
-            camera.quality = quality
-            
         time.sleep(agcwait)
-        camera.capture(picfile, i_format)
+        
+        if i_format == "jpeg":
+            camera.capture(picfile, i_format, quality=quality)
+        else:
+            camera.capture(picfile, i_format)
+            
+        
 
 # flush the buffer
 picfile.close()

--- a/lib/python/get_photo.py
+++ b/lib/python/get_photo.py
@@ -18,7 +18,7 @@ sharpness = int(sys.argv[11])
 imageeffect = sys.argv[12]
 agcwait = float(sys.argv[13])
 quality = int(sys.argv[14])
-led = bool(sys.argv[15])
+led = True if int(sys.argv[15]) == 1 else False
 
 # consider jpeg
 if fileFormat == "jpg":

--- a/locales/en-US/camerapi.json
+++ b/locales/en-US/camerapi.json
@@ -15,6 +15,8 @@
             "sharpness" : "Sharpness",
             "imageeffect" : "Image Effect",
             "agcwait" : "Wait for AGC",
+            "quality" : "Quality",
+            "led" : "LED",
             "res1" : "320x240",
             "res2" : "640x480",
             "res3" : "800x600",


### PR DESCRIPTION
Apologies for the messy PR; have to get out of the bad habit of editing files directly on GitHub. Tedious workflow though, to edit on my laptop, commit and push, and then update via npm on the Pi, for every change I want to test. Would be nice to be able to push straight from the module's directory in .node-red/node_modules/ so I could tweak-deploy-test-commit without having to dance around so much... 

In any case, this PR adds two more parameters to the camerapi node; `quality`, to set the amount of JPEG compression (ignored unless image format == "jpeg"), and "led" which controls the on-camera LED. The reason for adding `quality` is because I grab some images on a timer before passing them over a WWAN, and I thought that the filesize was unacceptably high (~600kb for a 1024x768 JPEG) - at a 15 min interval this would add up to ~1.8Gb per month! I find that a quality setting of 30 produces quite acceptable images, at less than half that size. 

The reason for the second parameter, `led`, is that I have a [Waveshare "IR-Cut" camera](http://www.waveshare.com/wiki/RPi_IR-CUT_Camera), which uses the LED signal to control the IR filter; turning the "LED" _on_ activates a small solenoid which inserts the IR filter in the light-path, while leaving it _off_ allows infra-red light to pass. Having the filter out introduces a purple cast to daytime images, and having it in limits the camera's ability to capture dark / IR illuminated scenes. 