### PR TITLE
Fix bug #5 and other minor bugs

### DIFF
--- a/camerapi.html
+++ b/camerapi.html
@@ -166,7 +166,7 @@
         defaults: {
             filemode: {value:"2", required:true},
             filename: {value:"", required:false},
-            filedefpath: {value:"0", required:true},
+            filedefpath: {value:"1", required:true},
             filepath: {value:"", required:false},
             fileformat: {value:"jpeg", required:true},
             resolution: {value:"1", required:true},
@@ -192,6 +192,8 @@
                 if (choose == "0") {
                 	console.log("Buffermode - yes");
                 	$("#filename").hide();
+                    $("#node-input-filedefpath").val("1");
+                    $("#node-input-filepath").val("");
                 	$("#filedefpath").hide();
                 	$("#filepath").hide();
                 	$("#fileformat").hide();
@@ -199,13 +201,13 @@
                 	console.log("Generate - yes");
                 	$("#filename").hide();
                     $("#node-input-filedefpath").val("1");
+                    $("#node-input-filepath").val("");
                 	$("#filedefpath").hide();
                 	$("#filepath").hide();
                 	$("#fileformat").hide();                    
                 } else {
                 	console.log("FileMode - yes");
                 	$("#filename").show();
-                    $("#node-input-filedefpath").val("1");
                 	$("#filedefpath").show();
                 	$("#filepath").hide();
                 	$("#fileformat").show();
@@ -220,6 +222,7 @@
                 } else {
                 	console.log("FileDefPath - yes");
                 	$("#filepath").hide();
+                    $("#node-input-filepath").val("");
                 }
             });
         },

--- a/camerapi.js
+++ b/camerapi.js
@@ -354,8 +354,15 @@ module.exports = function(RED) {
 		});
 
 		// CameraPi-TakePhoto has a close
-		node.on("close", function(done) {
-			node.closing = true;
+		// New function signature function(removed, done) included in Node-Red 0.17
+		node.on("close", function(removed, done) {
+			if (removed) {
+				// This node has been deleted
+				node.closing = true;
+			}
+			else {
+				// This node is being restarted
+			}
 			done();
 		});
 	}

--- a/locales/en-US/camerapi.json
+++ b/locales/en-US/camerapi.json
@@ -6,7 +6,7 @@
             "filedefpath" : "File default path", 
             "filepath" : "File Path", 
             "filemode" : "File Mode", 
-            "size" : "Image Resolution", 
+            "resolution" : "Image Resolution", 
             "fileformat" : "File Format",
             "filefqn" : "File Qualified Path and Name", 
             "brightness" : "Brightness",


### PR DESCRIPTION
- fix bug #5 in camerapi.html where the state of FileDefPath isn't remebered when using Filemode. It also fix the UI behavior and switching filemode states and filepath value.
- adjust "on close" event handler function to Node-Red 0.17 specification in camperapi.js
- fix "size" key, replacing it by "resolution", which is the correct key in locales/en-US/camerapi.json.