### PR TITLE
Fix an error with the latest uuid module

### DIFF
--- a/camerapi.js
+++ b/camerapi.js
@@ -62,8 +62,8 @@ module.exports = function(RED) {
 
 			var fsextra = require("fs-extra");
 			var fs = require("fs");
-			var uuidv4 = require("uuid/v4");
-			var uuid = uuidv4();
+			var uuidv4 = require("uuid");
+			var uuid = uuidv4.v4();
 			var os = require("os");
 			var localdir = __dirname;
 			var homedir = os.homedir();

--- a/camerapi.js
+++ b/camerapi.js
@@ -62,8 +62,8 @@ module.exports = function(RED) {
 
 			var fsextra = require("fs-extra");
 			var fs = require("fs");
-			var uuidv4 = require("uuid");
-			var uuid = uuidv4.v4();
+			const { v4: uuidv4 } = require('uuid');
+			var uuid = uuidv4();
 			var os = require("os");
 			var localdir = __dirname;
 			var homedir = os.homedir();


### PR DESCRIPTION
This program use the 'latest' version of uuid modue, and now causes an error when it requires 'uuid/v4'.
So I will add a quick fix (with using old JavaScript syntax) to follow the [uuid repo's README](https://github.com/uuidjs/uuid#deep-requires-no-longer-supported).


### note

I tested that the original code can work with Raspberry pi4 + Raspbian (2020-02-13 buster-full) + Node-Red v1.0.3 environment.
A friends was troubled with this ``require("uuid/v4")`` problem, but it may not be so common. However, I think it's safer to implement this fix.